### PR TITLE
Binds repository name and branch to status bar

### DIFF
--- a/GitBasic/Controls/StatusControl.xaml
+++ b/GitBasic/Controls/StatusControl.xaml
@@ -8,7 +8,7 @@
     d:DesignHeight="25"
     d:DesignWidth="1000"
     mc:Ignorable="d">
-    <Grid>
+    <Grid DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:StatusControl}}}">
         <StatusBar Background="{DynamicResource AccentBrush1}">
             <StatusBar.ItemsPanel>
                 <ItemsPanelTemplate>
@@ -25,13 +25,13 @@
                 <TextBlock
                     Margin="5,0"
                     Foreground="{DynamicResource ForegoundBrush}"
-                    Text="Repository" />
+                    Text="{Binding RepositoryName, Mode=OneWay}" />
             </StatusBarItem>
             <StatusBarItem Grid.Column="2">
                 <TextBlock
                     Margin="5,0"
                     Foreground="{DynamicResource ForegoundBrush}"
-                    Text="develop" />
+                    Text="{Binding BranchName, Mode=OneWay}" />
             </StatusBarItem>
         </StatusBar>
     </Grid>

--- a/GitBasic/Controls/StatusControl.xaml.cs
+++ b/GitBasic/Controls/StatusControl.xaml.cs
@@ -1,17 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace GitBasic.Controls
 {
@@ -24,5 +12,25 @@ namespace GitBasic.Controls
         {
             InitializeComponent();
         }
+
+        #region Dependency Properties
+
+        public string RepositoryName
+        {
+            get { return (string)GetValue(RepositoryNameProperty); }
+            set { SetValue(RepositoryNameProperty, value); }
+        }        
+        public static readonly DependencyProperty RepositoryNameProperty =
+            DependencyProperty.Register("RepositoryName", typeof(string), typeof(StatusControl), new PropertyMetadata(string.Empty));
+
+        public string BranchName
+        {
+            get { return (string)GetValue(BranchNameProperty); }
+            set { SetValue(BranchNameProperty, value); }
+        }
+        public static readonly DependencyProperty BranchNameProperty =
+            DependencyProperty.Register("BranchName", typeof(string), typeof(StatusControl), new PropertyMetadata(string.Empty));
+
+        #endregion
     }
 }

--- a/GitBasic/GitBasic.csproj
+++ b/GitBasic/GitBasic.csproj
@@ -117,8 +117,10 @@
     </Compile>
     <Compile Include="Lib\Command.cs" />
     <Compile Include="Lib\ExtensionMethods\ControlExtensions.cs" />
+    <Compile Include="Lib\ExtensionMethods\StringExtensions.cs" />
     <Compile Include="Lib\Reactive\Prop.cs" />
     <Compile Include="Lib\Reactive\ReactiveAction.cs" />
+    <Compile Include="Lib\Reactive\ReactiveProp.cs" />
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -162,7 +164,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainVM.cs" />
-    <Compile Include="Lib\Observable.cs" />
+    <Compile Include="Lib\Reactive\Observable.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/GitBasic/Lib/ExtensionMethods/StringExtensions.cs
+++ b/GitBasic/Lib/ExtensionMethods/StringExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace GitBasic
+{
+    public static class StringExtensions
+    {
+        public static string SubstringFromLast(this string value, char character)
+        {
+            int i = value.LastIndexOf(character);
+            return (i < 0) ? string.Empty : value.Substring(i + 1);
+        }       
+    }
+}

--- a/GitBasic/Lib/ExtensionMethods/StringExtensions.cs
+++ b/GitBasic/Lib/ExtensionMethods/StringExtensions.cs
@@ -2,6 +2,13 @@
 {
     public static class StringExtensions
     {
+        /// <summary>
+        /// Returns a substring starting after the last instance of the specified character.
+        /// If the specified character does not occur in the string, the result is empty.
+        /// </summary>
+        /// <param name="value">The string to get the substring from.</param>
+        /// <param name="character">The character after whose last instance the substring will be taken.</param>
+        /// <returns></returns>
         public static string SubstringFromLast(this string value, char character)
         {
             int i = value.LastIndexOf(character);

--- a/GitBasic/Lib/Reactive/Observable.cs
+++ b/GitBasic/Lib/Reactive/Observable.cs
@@ -2,7 +2,7 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
-namespace GitBasic
+namespace Reactive
 {
     public abstract class Observable : INotifyPropertyChanged
     {

--- a/GitBasic/Lib/Reactive/Prop.cs
+++ b/GitBasic/Lib/Reactive/Prop.cs
@@ -1,10 +1,6 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-
-namespace Reactive
+﻿namespace Reactive
 {
-    public class Prop<T> : INotifyPropertyChanged
+    public class Prop<T> : Observable
     {
         public Prop(T value = default(T))
         {
@@ -16,17 +12,6 @@ namespace Reactive
             get => _value;
             set => SetAndNotify(ref _value, value);
         }
-        private T _value;
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        private void SetAndNotify(ref T property, T value, [CallerMemberName] string propertyName = null)
-        {
-            if (EqualityComparer<T>.Default.Equals(property, value) == false)
-            {
-                property = value;
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-            }
-        }
+        private T _value;       
     }
 }

--- a/GitBasic/Lib/Reactive/ReactiveProp.cs
+++ b/GitBasic/Lib/Reactive/ReactiveProp.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Reactive
+{
+    public class ReactiveProp<T> : Observable, IDisposable
+    {
+        public ReactiveProp(Func<T> evaluator, params INotifyPropertyChanged[] dependencies)
+        {
+            _evaluator = evaluator;
+            _dependencies = dependencies;
+            Subscribe();
+        }
+
+        public T Value
+        {
+            get => _value;
+            private set => SetAndNotify(ref _value, value);
+        }
+        private T _value;
+
+        public void Dispose()
+        {
+            Unsubscribe();
+        }
+
+        private void Subscribe()
+        {
+            foreach (var dependency in _dependencies)
+            {
+                dependency.PropertyChanged += Dependency_PropertyChanged;
+            }
+        }
+
+        private void Unsubscribe()
+        {
+            foreach (var dependency in _dependencies)
+            {
+                dependency.PropertyChanged -= Dependency_PropertyChanged;
+            }
+        }
+
+        private void Dependency_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            Value = _evaluator();
+        }
+
+        private Func<T> _evaluator;
+        private INotifyPropertyChanged[] _dependencies;
+    }
+}

--- a/GitBasic/MainVM.cs
+++ b/GitBasic/MainVM.cs
@@ -4,11 +4,35 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using LibGit2Sharp;
+using System.Windows;
+using System.IO;
 
 namespace GitBasic
 {
     public class MainVM : Observable
     {
-        public Prop<string> WorkingDirectory { get; set; } = new Prop<string>(Properties.Settings.Default.WorkingDirectory);
+        public Prop<string> WorkingDirectory { get; set; } = new Prop<string>();
+        public ReactiveProp<Repository> Repo { get; set; }
+        public ReactiveProp<string> RepositoryName { get; set; }
+        public ReactiveProp<string> BranchName { get; set; }
+
+        public MainVM()
+        {            
+            Repo = new ReactiveProp<Repository>(UpdateRepository, WorkingDirectory);
+            RepositoryName = new ReactiveProp<string>(() => { return (Repo.Value != null) ? Repo.Value.Info.WorkingDirectory.TrimEnd('\\').SubstringFromLast('\\') : string.Empty; }, Repo);
+
+            // TODO: This needs to update on branch changes as well. Currently only watching Repo which changes on directory changes.
+            BranchName = new ReactiveProp<string>(() => { return (Repo.Value != null) ? Repo.Value.Head.FriendlyName : string.Empty; }, Repo);
+
+            WorkingDirectory.Value = Properties.Settings.Default.WorkingDirectory;
+        }        
+
+        private Repository UpdateRepository()
+        {
+            Repo.Value?.Dispose();
+            string repoPath = Repository.Discover(WorkingDirectory.Value);
+            return (repoPath != null) ? new Repository(repoPath) : null;
+        }
     }
 }

--- a/GitBasic/MainWindow.xaml
+++ b/GitBasic/MainWindow.xaml
@@ -15,7 +15,7 @@
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
     <controls:MetroWindow.Resources>
-        <local:MainVM x:Key="MainVM"></local:MainVM>
+        <local:MainVM x:Key="MainVM" />
     </controls:MetroWindow.Resources>
     <controls:MetroWindow.TitleBarIcon>
         <Image
@@ -51,7 +51,7 @@
                 <ColumnDefinition Width="0.3*" />
             </Grid.ColumnDefinitions>
 
-            <controls:ConsoleControl WorkingDirectory="{Binding WorkingDirectory.Value}" Grid.Column="0" />
+            <controls:ConsoleControl Grid.Column="0" WorkingDirectory="{Binding WorkingDirectory.Value, Mode=TwoWay}" />
 
             <GridSplitter
                 Grid.Column="1"
@@ -63,6 +63,10 @@
         </Grid>
 
         <!--  Row 3  -->
-        <controls:StatusControl Grid.Row="3" DockPanel.Dock="Bottom" />
+        <controls:StatusControl
+            Grid.Row="3"
+            BranchName="{Binding BranchName.Value}"
+            DockPanel.Dock="Bottom"
+            RepositoryName="{Binding RepositoryName.Value}" />
     </Grid>
 </controls:MetroWindow>


### PR DESCRIPTION
Completed the following:

- Created reactive property - property value derives from function when dependencies raise change events.

- Put Repo property in the MainVM

- Bound Repo name and branch name to status bar (branch name will still need more work, but will implement more on future task).

Unit Test paperwork:
[UnitTestDoc1.xlsx](https://github.com/MattTheMan/git-basic/files/1726527/UnitTestDoc1.xlsx)
